### PR TITLE
add selectBy

### DIFF
--- a/src/List/Selection.elm
+++ b/src/List/Selection.elm
@@ -5,6 +5,7 @@ module List.Selection
         , fromList
         , map
         , select
+        , selectBy
         , selected
         , toList
         )
@@ -16,7 +17,7 @@ The invariants here:
   - You can select _at most_ one item.
   - You can't select an item that isn't part of the list.
 
-@docs Selection, fromList, toList, select, deselect, selected, map
+@docs Selection, fromList, toList, select, selectBy, deselect, selected, map
 
 -}
 
@@ -57,10 +58,24 @@ Attempting to select an item that doesn't exist is a no-op.
 
 -}
 select : a -> Selection a -> Selection a
-select el (Selection original items) =
+select el selection =
+    selectBy ((==) el) selection
+
+
+{-| Mark an item as selected by specifying a function. This will select the
+first item for which the function returns `True`. Any previously selected item
+will be unselected.
+
+    fromList ["Burrito", "Chicken Wrap", "Taco Salad"]
+        |> selectBy (String.startsWith "B")
+        |> selected --> Just "Burrito"
+
+-}
+selectBy : (a -> Bool) -> Selection a -> Selection a
+selectBy query (Selection original items) =
     Selection
         (items
-            |> List.filter ((==) el)
+            |> List.filter query
             |> List.head
             |> Maybe.map Just
             |> Maybe.withDefault original


### PR DESCRIPTION
add `selectBy : (a -> Bool) -> Selection a -> Selection a` and redefine `select` in terms of `selectBy`. I'm not sure if this is the right API for this, but I want to discuss it.

This really feels like it surfaces the fact that we don't handle duplicates at all. When you have to provide the entire value being selected this works just fine, but when you need to select something positionally it doesn't work nearly as well. It might mean we need to reevaluate the data structure used here and use a zipper instead of a maybe and a list. That would solve it, but it complicates the implementation quite a bit.

If merged, fixes #1.