### PR TITLE
implement and test filter-like functionality

### DIFF
--- a/src/List/Selection.elm
+++ b/src/List/Selection.elm
@@ -170,28 +170,13 @@ mapSelected mappers (Selection selected items) =
         )
 
 
-{-| Filter all items where predicate evaluates to false, preserving unfiltered
-selected item.
+{-| Filter all items where predicate evaluates to false, preserving selected item
+when unfiltered.
 
     fromList [1, 2, 3]
         |> select 2
         |> filter ((>) 2)
         |> toList --> [1]
-
-    fromList [1, 2, 3]
-        |> select 2
-        |> filter ((>) 2)
-        |> selected --> Nothing
-
-    fromList [1, 2, 3]
-        |> select 2
-        |> filter ((<) 1)
-        |> toList --> [2, 3]
-
-    fromList [1, 2, 3]
-        |> select 2
-        |> filter ((<) 1)
-        |> selected --> Just 2
 
 -}
 filter : (a -> Bool) -> Selection a -> Selection a
@@ -202,10 +187,10 @@ filter predicate (Selection selected items) =
                 |> List.filter predicate
                 |> fromList
     in
-        case selected of
-            Just selection ->
-                filteredSelection
-                    |> select selection
+    case selected of
+        Just selection ->
+            filteredSelection
+                |> select selection
 
-            Nothing ->
-                filteredSelection
+        Nothing ->
+            filteredSelection

--- a/src/List/Selection.elm
+++ b/src/List/Selection.elm
@@ -2,6 +2,7 @@ module List.Selection
     exposing
         ( Selection
         , deselect
+        , filter
         , fromList
         , map
         , mapSelected
@@ -33,7 +34,7 @@ But, these only hold if there are no duplicates in your list.
 
 ## Transforming
 
-@docs map, mapSelected
+@docs map, mapSelected, filter
 
 -}
 
@@ -167,3 +168,44 @@ mapSelected mappers (Selection selected items) =
             )
             items
         )
+
+
+{-| Filter all items where predicate evaluates to false, preserving unfiltered
+selected item.
+
+    fromList [1, 2, 3]
+        |> select 2
+        |> filter ((>) 2)
+        |> toList --> [1]
+
+    fromList [1, 2, 3]
+        |> select 2
+        |> filter ((>) 2)
+        |> selected --> Nothing
+
+    fromList [1, 2, 3]
+        |> select 2
+        |> filter ((<) 1)
+        |> toList --> [2, 3]
+
+    fromList [1, 2, 3]
+        |> select 2
+        |> filter ((<) 1)
+        |> selected --> Just 2
+
+-}
+filter : (a -> Bool) -> Selection a -> Selection a
+filter predicate (Selection selected items) =
+    let
+        filteredSelection =
+            items
+                |> List.filter predicate
+                |> fromList
+    in
+        case selected of
+            Just selection ->
+                filteredSelection
+                    |> select selection
+
+            Nothing ->
+                filteredSelection

--- a/tests/List/SelectionSpec.elm
+++ b/tests/List/SelectionSpec.elm
@@ -13,10 +13,12 @@ selection : Fuzzer comparable -> Fuzzer (Selection comparable)
 selection =
     Fuzz.list
         -- our invariants only hold for lists with unique items, so remove those.
-        >> Fuzz.map Set.fromList
+        >>
+            Fuzz.map Set.fromList
         >> Fuzz.map Set.toList
         -- construct our Selection!
-        >> Fuzz.map Selection.fromList
+        >>
+            Fuzz.map Selection.fromList
 
 
 nonemptySelection : Fuzzer comparable -> Fuzzer ( comparable, Selection comparable )
@@ -32,6 +34,11 @@ nonemptySelection kind =
         )
         kind
         (Fuzz.list kind)
+
+
+isEven : Int -> Bool
+isEven x =
+    x % 2 == 0
 
 
 spec : Test
@@ -105,5 +112,27 @@ spec =
                     items
                         |> Selection.mapSelected { selected = (*) 2, rest = identity }
                         |> Expect.equal items
+            ]
+        , describe "filtering"
+            [ fuzz (selection Fuzz.int) "works like regular filter on lists" <|
+                \items ->
+                    items
+                        |> Selection.toList
+                        |> List.filter isEven
+                        |> Expect.equal (Selection.filter isEven items |> Selection.toList)
+            , fuzz (nonemptySelection Fuzz.int) "preserves selected item" <|
+                \( item, items ) ->
+                    if item |> isEven then
+                        items
+                            |> Selection.select item
+                            |> Selection.filter isEven
+                            |> Selection.selected
+                            |> Expect.equal (Just item)
+                    else
+                        items
+                            |> Selection.select item
+                            |> Selection.filter isEven
+                            |> Selection.selected
+                            |> Expect.equal Nothing
             ]
         ]


### PR DESCRIPTION
I ran into this use case and thought it might be beneficial to others using the library. Adding this functionality prevents consumers of the library from calling `fromList` and `toList` frequently, while maintaining the selected item--provided the item isn't filtered by the predicate.